### PR TITLE
summoner name으로 encryptedID 받아오는 부분 추가했습니다.

### DIFF
--- a/src/main/java/ajou/realcoding/team3/riotGamesPerformances/api/RiotGamesPerformancesAPIClient.java
+++ b/src/main/java/ajou/realcoding/team3/riotGamesPerformances/api/RiotGamesPerformancesAPIClient.java
@@ -10,20 +10,22 @@ import org.springframework.web.client.RestTemplate;
 @Service
 public class RiotGamesPerformancesAPIClient {
 
-    private final String apikey = "RGAPI-b241cfe9-a7f8-4382-bf1d-c63b6036c33b";
-    private final String summonorV4Url = "https://kr.api.riotgames.com/lol/summoner/v4/summoners/by-name/{summonerName}?api_key={apikey}";
-    private final String leagueV4Url = "https://kr.api.riotgames.com/lol/league/v4/entries/by-summoner/{encryptedSummonerId}?api_key={apikey}";
+    private final String apikey = "RGAPI-81174976-ddc1-486f-8b4a-5a6ff36ed103";
+    private final String baseUrl = "https://kr.api.riotgames.com";
+    private final String authUrl = "?api_key={apikey}";
+    private final String summonerV4Url = "/lol/summoner/v4/summoners/by-name/{summonerName}";
+    private final String leagueV4Url = "/lol/league/v4/entries/by-summoner/{encryptedSummonerId}";
 
 
     @Autowired
     RestTemplate restTemplate;
 
     public PlayerEncryptedID requestEncryptedID(String summonerName) {
-        return restTemplate.exchange(summonorV4Url, HttpMethod.GET, null, PlayerEncryptedID.class, summonerName, apikey).getBody();
+        return restTemplate.exchange(baseUrl+summonerV4Url+authUrl, HttpMethod.GET, null, PlayerEncryptedID.class, summonerName, apikey).getBody();
     }
 
     public PlayerPerformance[] requestPerformance(String encryptedSummonerId) {
-        PlayerPerformance[] performances = restTemplate.exchange(leagueV4Url, HttpMethod.GET, null, PlayerPerformance[].class, encryptedSummonerId, apikey).getBody();
+        PlayerPerformance[] performances = restTemplate.exchange(baseUrl+leagueV4Url+authUrl, HttpMethod.GET, null, PlayerPerformance[].class, encryptedSummonerId, apikey).getBody();
         return performances;
     }
 

--- a/src/main/java/ajou/realcoding/team3/riotGamesPerformances/controller/PerformanceController.java
+++ b/src/main/java/ajou/realcoding/team3/riotGamesPerformances/controller/PerformanceController.java
@@ -1,4 +1,21 @@
 package ajou.realcoding.team3.riotGamesPerformances.controller;
 
+import ajou.realcoding.team3.riotGamesPerformances.domain.PlayerPerformance;
+import ajou.realcoding.team3.riotGamesPerformances.service.GameService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
 public class PerformanceController {
+    @Autowired
+    GameService gameService;
+
+    @GetMapping("/lol/summoner/get-player-performance/by-name/{summonerName}")
+    public PlayerPerformance getPlayerPerformance(@PathVariable String summonerName){
+        String encryptedID = gameService.getEncryptedIdBySummonerName(summonerName).getId();
+        return gameService.getPerformanceByEncryptedSummonerID(encryptedID);
+    }
+
 }

--- a/src/main/java/ajou/realcoding/team3/riotGamesPerformances/controller/PerformanceController.java
+++ b/src/main/java/ajou/realcoding/team3/riotGamesPerformances/controller/PerformanceController.java
@@ -4,7 +4,7 @@ import ajou.realcoding.team3.riotGamesPerformances.domain.PlayerPerformance;
 import ajou.realcoding.team3.riotGamesPerformances.service.GameService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -12,8 +12,8 @@ public class PerformanceController {
     @Autowired
     GameService gameService;
 
-    @GetMapping("/lol/summoner/get-player-performance/by-name/{summonerName}")
-    public PlayerPerformance getPlayerPerformance(@PathVariable String summonerName){
+    @GetMapping("/lol/summoner/get-player-performance/by-name")
+    public PlayerPerformance getPlayerPerformance(@RequestParam String summonerName){
         String encryptedID = gameService.getEncryptedIdBySummonerName(summonerName).getId();
         return gameService.getPerformanceByEncryptedSummonerID(encryptedID);
     }

--- a/src/main/java/ajou/realcoding/team3/riotGamesPerformances/service/GameService.java
+++ b/src/main/java/ajou/realcoding/team3/riotGamesPerformances/service/GameService.java
@@ -1,4 +1,21 @@
 package ajou.realcoding.team3.riotGamesPerformances.service;
 
+import ajou.realcoding.team3.riotGamesPerformances.api.RiotGamesPerformancesAPIClient;
+import ajou.realcoding.team3.riotGamesPerformances.domain.PlayerEncryptedID;
+import ajou.realcoding.team3.riotGamesPerformances.domain.PlayerPerformance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
 public class GameService {
+    @Autowired
+    RiotGamesPerformancesAPIClient riotGamesPerformancesAPIClient;
+
+    public PlayerEncryptedID getEncryptedIdBySummonerName(String summonerName) {
+        return riotGamesPerformancesAPIClient.requestEncryptedID(summonerName);
+    }
+
+    public PlayerPerformance getPerformanceByEncryptedSummonerID(String encryptedID) {
+        return null;
+    }
 }


### PR DESCRIPTION
- RiotGamesPerformancesAPIClient에서 summonerV4Url와 leagueV4Url을 base 부분과 auth 부분으로 분리했습니다.

- PerformanceController에 `/lol/summoner/get-player-performance/by-name/{summonerName}` 경로로 Service에서 summonerName으로 얻어온 encryptedID 로 player의 performance를 얻어와 반환하는 메서드를 추가했습니다.  
(Service의 `getPerformanceByEncryptedSummonerID()`는 아직 구현하지 않았습니다.)

- GameService에 `@Autowired`로 의존성을 주입한 `RiotGamesPerformancesAPIClient ` 변수를 추가했고, encryptedId를 요청하는 함수를 호출하는 메서드를 구현했습니다. 

확인해주시면 master 브랜치에 merge하겠습니다.
