### PR TITLE
DB에 소환사 정보를 배열로 저장하는 함수 구현 및 수정

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,9 @@
 	</properties>
 
 	<dependencies>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 
 		<dependency>
@@ -30,35 +29,25 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-            <version>5.1.8.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.data</groupId>
-            <artifactId>spring-data-mongodb</artifactId>
-            <version>2.1.4.RELEASE</version>
-        </dependency>
 		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-webmvc</artifactId>
-			<version>5.1.8.RELEASE</version>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.8</version>
 		</dependency>
-        <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-spring-web</artifactId>
-            <version>2.9.2</version>
-        </dependency>
 		<dependency>
 			<groupId>io.springfox</groupId>
 			<artifactId>springfox-swagger2</artifactId>
 			<version>2.9.2</version>
 		</dependency>
 		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<version>1.18.8</version>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger-ui</artifactId>
+			<version>2.9.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-mongodb</artifactId>
+			<version>2.1.4.RELEASE</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/ajou/realcoding/team3/riotGamesPerformances/api/RiotGamesPerformancesAPIClient.java
+++ b/src/main/java/ajou/realcoding/team3/riotGamesPerformances/api/RiotGamesPerformancesAPIClient.java
@@ -10,7 +10,7 @@ import org.springframework.web.client.RestTemplate;
 @Service
 public class RiotGamesPerformancesAPIClient {
 
-    private final String apikey = "RGAPI-81174976-ddc1-486f-8b4a-5a6ff36ed103";
+    private final String apikey = "RGAPI-8fb11f7c-fa7b-4521-9444-9cb4c8c669d9";
     private final String baseUrl = "https://kr.api.riotgames.com";
     private final String authUrl = "?api_key={apikey}";
     private final String summonerV4Url = "/lol/summoner/v4/summoners/by-name/{summonerName}";

--- a/src/main/java/ajou/realcoding/team3/riotGamesPerformances/controller/PerformanceController.java
+++ b/src/main/java/ajou/realcoding/team3/riotGamesPerformances/controller/PerformanceController.java
@@ -13,7 +13,7 @@ public class PerformanceController {
     GameService gameService;
 
     @GetMapping("/lol/summoner/get-player-performance/by-name")
-    public PlayerPerformance getPlayerPerformance(@RequestParam String summonerName){
+    public PlayerPerformance[] getPlayerPerformance(@RequestParam String summonerName){
         String encryptedID = gameService.getEncryptedIdBySummonerName(summonerName).getId();
         return gameService.getPerformanceByEncryptedSummonerID(encryptedID);
     }

--- a/src/main/java/ajou/realcoding/team3/riotGamesPerformances/repository/CurrentPerformanceRepository.java
+++ b/src/main/java/ajou/realcoding/team3/riotGamesPerformances/repository/CurrentPerformanceRepository.java
@@ -23,12 +23,11 @@ public class CurrentPerformanceRepository {
     }
 
     public PlayerPerformance[] findCurrentPerformance(String encryptedSummonerId, PlayerPerformance[] playerPerformances) {
-        PlayerPerformance[] result = playerPerformances;
-        int cnt = 0;
+        int queueTypeCount = 0;
         for(int i=0; i<playerPerformances.length; i++) {
             Query query = Query.query(Criteria.where("summonerId").is(playerPerformances[i].getSummonerId()));
-            result[cnt] = mongoTemplate.findOne(query, PlayerPerformance.class);
+            playerPerformances[queueTypeCount] = mongoTemplate.findOne(query, PlayerPerformance.class);
         }
-        return result;
+        return playerPerformances;
     }
 }

--- a/src/main/java/ajou/realcoding/team3/riotGamesPerformances/repository/CurrentPerformanceRepository.java
+++ b/src/main/java/ajou/realcoding/team3/riotGamesPerformances/repository/CurrentPerformanceRepository.java
@@ -14,18 +14,21 @@ public class CurrentPerformanceRepository {
     @Autowired
     MongoTemplate mongoTemplate;
 
-    public void manageCurrentPerformance(PlayerPerformance[] playerPerformances){
-        for(int i=0; i<playerPerformances.length; i++)
-        {
+    public void manageCurrentPerformance(PlayerPerformance[] playerPerformances) {
+        for (int i = 0; i < playerPerformances.length; i++) {
             Query query = Query.query(Criteria.where("summonerId").is(playerPerformances[i].getSummonerId()));
+            mongoTemplate.insert(playerPerformances[i]);
         }
-
-        mongoTemplate.insert(playerPerformances);
 
     }
 
-    public PlayerPerformance findCurrentPerformance(String encryptedSummonerId) {
-        Query query = Query.query(Criteria.where("summonerId").is(encryptedSummonerId));
-        return mongoTemplate.findOne(query, PlayerPerformance.class);
+    public PlayerPerformance[] findCurrentPerformance(String encryptedSummonerId, PlayerPerformance[] playerPerformances) {
+        PlayerPerformance[] result = playerPerformances;
+        int cnt = 0;
+        for(int i=0; i<playerPerformances.length; i++) {
+            Query query = Query.query(Criteria.where("summonerId").is(playerPerformances[i].getSummonerId()));
+            result[cnt] = mongoTemplate.findOne(query, PlayerPerformance.class);
+        }
+        return result;
     }
 }

--- a/src/main/java/ajou/realcoding/team3/riotGamesPerformances/service/GameService.java
+++ b/src/main/java/ajou/realcoding/team3/riotGamesPerformances/service/GameService.java
@@ -3,6 +3,7 @@ package ajou.realcoding.team3.riotGamesPerformances.service;
 import ajou.realcoding.team3.riotGamesPerformances.api.RiotGamesPerformancesAPIClient;
 import ajou.realcoding.team3.riotGamesPerformances.domain.PlayerEncryptedID;
 import ajou.realcoding.team3.riotGamesPerformances.domain.PlayerPerformance;
+import ajou.realcoding.team3.riotGamesPerformances.repository.CurrentPerformanceRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -10,12 +11,15 @@ import org.springframework.stereotype.Service;
 public class GameService {
     @Autowired
     RiotGamesPerformancesAPIClient riotGamesPerformancesAPIClient;
+    @Autowired
+    CurrentPerformanceRepository currentPerformanceRepository;
 
     public PlayerEncryptedID getEncryptedIdBySummonerName(String summonerName) {
         return riotGamesPerformancesAPIClient.requestEncryptedID(summonerName);
     }
 
-    public PlayerPerformance getPerformanceByEncryptedSummonerID(String encryptedID) {
-        return null;
+    public PlayerPerformance getPerformanceByEncryptedSummonerID(String encryptedSummonerId) {
+        currentPerformanceRepository.manageCurrentPerformance(riotGamesPerformancesAPIClient.requestPerformance(encryptedSummonerId));
+        return currentPerformanceRepository.findCurrentPerformance(encryptedSummonerId);
     }
 }

--- a/src/main/java/ajou/realcoding/team3/riotGamesPerformances/service/GameService.java
+++ b/src/main/java/ajou/realcoding/team3/riotGamesPerformances/service/GameService.java
@@ -7,6 +7,8 @@ import ajou.realcoding.team3.riotGamesPerformances.repository.CurrentPerformance
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public class GameService {
     @Autowired
@@ -18,8 +20,9 @@ public class GameService {
         return riotGamesPerformancesAPIClient.requestEncryptedID(summonerName);
     }
 
-    public PlayerPerformance getPerformanceByEncryptedSummonerID(String encryptedSummonerId) {
-        currentPerformanceRepository.manageCurrentPerformance(riotGamesPerformancesAPIClient.requestPerformance(encryptedSummonerId));
-        return currentPerformanceRepository.findCurrentPerformance(encryptedSummonerId);
+    public PlayerPerformance[] getPerformanceByEncryptedSummonerID(String encryptedSummonerId) {
+        PlayerPerformance[] playerPerformances = riotGamesPerformancesAPIClient.requestPerformance(encryptedSummonerId);
+        currentPerformanceRepository.manageCurrentPerformance(playerPerformances);
+        return currentPerformanceRepository.findCurrentPerformance(encryptedSummonerId, playerPerformances);
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18344582/61296293-cc2fae80-a814-11e9-8a52-6a7259eea211.png)

CurrentPerformanceRepository 클래스에 있는 manageCurrentPerformance 함수를 배열 통채로 DB에 넣지 않고 반복문을 통해 element 한 개씩 넣도록 수정했습니다.

그리고 findCurrentPerformance 함수를 array 타입으로 수정하여 찾고자 하는 소환사의 정보를 바로 배열로 찾을 수 있도록 수정했습니다.

또한
PerformanceController 클래스의 getPlayerPerformance 함수와
GameService 클래스의 getPerformanceByEncryptedSummonerID 함수를 array 타입으로 수정하였습니다.
저희가 DB에 결국 array로 저장이 되기 때문에 소환사 정보를 다루는 함수들은 array로 return 타입을 바꿔주어야 한다고 판단했습니다.

현재 DB에 중복 삽입되는 것까지 확인하였습니다. 업데이트 함수만 추가하면 될 것 같습니다.