### PR TITLE
(Re) DB에 소환사 정보를 배열로 저장하는 함수 구현 및 수정

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,9 @@
 	</properties>
 
 	<dependencies>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 
 		<dependency>
@@ -30,35 +29,25 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-            <version>5.1.8.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.data</groupId>
-            <artifactId>spring-data-mongodb</artifactId>
-            <version>2.1.4.RELEASE</version>
-        </dependency>
 		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-webmvc</artifactId>
-			<version>5.1.8.RELEASE</version>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.8</version>
 		</dependency>
-        <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-spring-web</artifactId>
-            <version>2.9.2</version>
-        </dependency>
 		<dependency>
 			<groupId>io.springfox</groupId>
 			<artifactId>springfox-swagger2</artifactId>
 			<version>2.9.2</version>
 		</dependency>
 		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<version>1.18.8</version>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger-ui</artifactId>
+			<version>2.9.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-mongodb</artifactId>
+			<version>2.1.4.RELEASE</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/ajou/realcoding/team3/riotGamesPerformances/api/RiotGamesPerformancesAPIClient.java
+++ b/src/main/java/ajou/realcoding/team3/riotGamesPerformances/api/RiotGamesPerformancesAPIClient.java
@@ -10,7 +10,7 @@ import org.springframework.web.client.RestTemplate;
 @Service
 public class RiotGamesPerformancesAPIClient {
 
-    private final String apikey = "RGAPI-81174976-ddc1-486f-8b4a-5a6ff36ed103";
+    private final String apikey = "RGAPI-8fb11f7c-fa7b-4521-9444-9cb4c8c669d9";
     private final String baseUrl = "https://kr.api.riotgames.com";
     private final String authUrl = "?api_key={apikey}";
     private final String summonerV4Url = "/lol/summoner/v4/summoners/by-name/{summonerName}";

--- a/src/main/java/ajou/realcoding/team3/riotGamesPerformances/controller/PerformanceController.java
+++ b/src/main/java/ajou/realcoding/team3/riotGamesPerformances/controller/PerformanceController.java
@@ -7,13 +7,15 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 public class PerformanceController {
     @Autowired
     GameService gameService;
 
     @GetMapping("/lol/summoner/get-player-performance/by-name")
-    public PlayerPerformance getPlayerPerformance(@RequestParam String summonerName){
+    public List<PlayerPerformance> getPlayerPerformance(@RequestParam String summonerName){
         String encryptedID = gameService.getEncryptedIdBySummonerName(summonerName).getId();
         return gameService.getPerformanceByEncryptedSummonerID(encryptedID);
     }

--- a/src/main/java/ajou/realcoding/team3/riotGamesPerformances/repository/CurrentPerformanceRepository.java
+++ b/src/main/java/ajou/realcoding/team3/riotGamesPerformances/repository/CurrentPerformanceRepository.java
@@ -5,8 +5,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public class CurrentPerformanceRepository {
@@ -14,18 +15,16 @@ public class CurrentPerformanceRepository {
     @Autowired
     MongoTemplate mongoTemplate;
 
-    public void manageCurrentPerformance(PlayerPerformance[] playerPerformances){
-        for(int i=0; i<playerPerformances.length; i++)
-        {
-            Query query = Query.query(Criteria.where("summonerId").is(playerPerformances[i].getSummonerId()));
+    public void manageCurrentPerformance(PlayerPerformance[] playerPerformances) {
+        for (PlayerPerformance playerPerformance : playerPerformances) {
+            Query query = Query.query(Criteria.where("summonerId").is(playerPerformance.getSummonerId()));
+            query.addCriteria(Criteria.where("queueType").is(playerPerformance.getQueueType()));
+            mongoTemplate.insert(playerPerformance);
         }
-
-        mongoTemplate.insert(playerPerformances);
-
     }
 
-    public PlayerPerformance findCurrentPerformance(String encryptedSummonerId) {
+    public List<PlayerPerformance> findCurrentPerformance(String encryptedSummonerId) {
         Query query = Query.query(Criteria.where("summonerId").is(encryptedSummonerId));
-        return mongoTemplate.findOne(query, PlayerPerformance.class);
+        return mongoTemplate.find(query, PlayerPerformance.class, "playerPerformance");
     }
 }

--- a/src/main/java/ajou/realcoding/team3/riotGamesPerformances/service/GameService.java
+++ b/src/main/java/ajou/realcoding/team3/riotGamesPerformances/service/GameService.java
@@ -3,19 +3,25 @@ package ajou.realcoding.team3.riotGamesPerformances.service;
 import ajou.realcoding.team3.riotGamesPerformances.api.RiotGamesPerformancesAPIClient;
 import ajou.realcoding.team3.riotGamesPerformances.domain.PlayerEncryptedID;
 import ajou.realcoding.team3.riotGamesPerformances.domain.PlayerPerformance;
+import ajou.realcoding.team3.riotGamesPerformances.repository.CurrentPerformanceRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class GameService {
     @Autowired
     RiotGamesPerformancesAPIClient riotGamesPerformancesAPIClient;
+    @Autowired
+    CurrentPerformanceRepository currentPerformanceRepository;
 
     public PlayerEncryptedID getEncryptedIdBySummonerName(String summonerName) {
         return riotGamesPerformancesAPIClient.requestEncryptedID(summonerName);
     }
 
-    public PlayerPerformance getPerformanceByEncryptedSummonerID(String encryptedID) {
-        return null;
+    public List<PlayerPerformance> getPerformanceByEncryptedSummonerID(String encryptedID) {
+        currentPerformanceRepository.manageCurrentPerformance(riotGamesPerformancesAPIClient.requestPerformance(encryptedID));
+        return currentPerformanceRepository.findCurrentPerformance(encryptedID);
     }
 }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/18344582/61299917-f9cc2600-a81b-11e9-9fe0-ec8b038f2213.png)


CurrentPerformanceRepository 클래스에 있는 manageCurrentPerformance 함수를 배열 통채로 DB에 넣지 않고 한 개씩 넣도록 수정했습니다.

그리고 findCurrentPerformance 함수를 List 타입으로 수정하여 찾고자 하는 소환사의 정보를 바로 배열로 찾을 수 있도록 수정했습니다.

또한
PerformanceController 클래스의 getPlayerPerformance 함수와
GameService 클래스의 getPerformanceByEncryptedSummonerID 함수를 List 타입으로 수정하였습니다.

현재 DB에 중복 삽입되는 것까지 확인하였습니다. 업데이트 함수만 추가하면 될 것 같습니다.